### PR TITLE
Add --use-unadjusted-pvalue argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ usage: rmats_long.py [-h] --abundance ABUNDANCE --updated-gtf UPDATED_GTF
                      [--process-top-n PROCESS_TOP_N]
                      [--plot-file-type {.pdf,.png}]
                      [--diff-transcripts DIFF_TRANSCRIPTS]
-                     [--adj-pvalue ADJ_PVALUE]
+                     [--adj-pvalue ADJ_PVALUE] [--use-unadjusted-pvalue]
                      [--delta-proportion DELTA_PROPORTION]
                      [--compare-all-within-gene]
 
@@ -100,6 +100,8 @@ options:
                         given then skip the differential isoform calculation.
   --adj-pvalue ADJ_PVALUE
                         The cutoff for adjusted p-value (default 0.05)
+  --use-unadjusted-pvalue
+                        Use pvalue instead of adj_pvalue for the cutoff
   --delta-proportion DELTA_PROPORTION
                         The cutoff for delta isoform proportion (default 0.1)
   --compare-all-within-gene
@@ -144,6 +146,7 @@ usage: detect_differential_isoforms.py [-h] --abundance ABUNDANCE --out-dir
                                        OUT_DIR --group-1 GROUP_1 --group-2
                                        GROUP_2 [--num-threads NUM_THREADS]
                                        [--adj-pvalue ADJ_PVALUE]
+                                       [--use-unadjusted-pvalue]
                                        [--delta-proportion DELTA_PROPORTION]
 
 Detect differential isoform expression using DRIMSeq
@@ -163,6 +166,8 @@ options:
                         The number of threads to use (default: 1)
   --adj-pvalue ADJ_PVALUE
                         The cutoff for adjusted p-value (default: 0.05)
+  --use-unadjusted-pvalue
+                        Use pvalue instead of adj_pvalue for the cutoff
   --delta-proportion DELTA_PROPORTION
                         The cutoff for delta isoform proportion (default: 0.1)
 ```
@@ -173,6 +178,7 @@ python count_significant_isoforms.py -h
 usage: count_significant_isoforms.py [-h] --diff-transcripts DIFF_TRANSCRIPTS
                                      --out-tsv OUT_TSV
                                      [--adj-pvalue ADJ_PVALUE]
+                                     [--use-unadjusted-pvalue]
                                      [--delta-proportion DELTA_PROPORTION]
 
 Count isoforms that meet the cutoff values
@@ -185,6 +191,8 @@ options:
                         values
   --adj-pvalue ADJ_PVALUE
                         The cutoff for adjusted p-value (default: 0.05)
+  --use-unadjusted-pvalue
+                        Use pvalue instead of adj_pvalue for the cutoff
   --delta-proportion DELTA_PROPORTION
                         The cutoff for delta isoform proportion (default: 0.1)
 ```

--- a/scripts/count_significant_isoforms.py
+++ b/scripts/count_significant_isoforms.py
@@ -19,6 +19,9 @@ def parse_args():
         type=float,
         default=0.05,
         help='The cutoff for adjusted p-value (default: %(default)s)')
+    parser.add_argument('--use-unadjusted-pvalue',
+                        action='store_true',
+                        help='Use pvalue instead of adj_pvalue for the cutoff')
     parser.add_argument(
         '--delta-proportion',
         type=float,
@@ -29,19 +32,24 @@ def parse_args():
 
 
 def count_significant_isoforms(transcript_path, out_path, adj_pvalue,
-                               delta_proportion):
+                               use_unadjusted_pvalue, delta_proportion):
     with open(transcript_path, 'rt') as in_handle:
         with open(out_path, 'wt') as out_handle:
             count_significant_isoforms_with_handles(in_handle, out_handle,
                                                     adj_pvalue,
+                                                    use_unadjusted_pvalue,
                                                     delta_proportion)
 
 
 def count_significant_isoforms_with_handles(in_handle, out_handle, adj_pvalue,
+                                            use_unadjusted_pvalue,
                                             delta_proportion):
     genes = set()
     isoform_count = 0
     pvalue_col_name = 'adj_pvalue'
+    if use_unadjusted_pvalue:
+        pvalue_col_name = 'pvalue'
+
     delta_prop_col_name = 'delta_isoform_proportion'
     for line_i, line in enumerate(in_handle):
         columns = line.rstrip('\n').split('\t')
@@ -74,7 +82,8 @@ def count_significant_isoforms_with_handles(in_handle, out_handle, adj_pvalue,
 def main():
     args = parse_args()
     count_significant_isoforms(args.diff_transcripts, args.out_tsv,
-                               args.adj_pvalue, args.delta_proportion)
+                               args.adj_pvalue, args.use_unadjusted_pvalue,
+                               args.delta_proportion)
 
 
 if __name__ == '__main__':

--- a/scripts/detect_differential_isoforms.py
+++ b/scripts/detect_differential_isoforms.py
@@ -36,6 +36,9 @@ def parse_args():
         type=float,
         default=0.05,
         help='The cutoff for adjusted p-value (default: %(default)s)')
+    parser.add_argument('--use-unadjusted-pvalue',
+                        action='store_true',
+                        help='Use pvalue instead of adj_pvalue for the cutoff')
     parser.add_argument(
         '--delta-proportion',
         type=float,
@@ -105,7 +108,8 @@ def calculate_isoform_proportion(script_dir, out_dir, abundance_path,
 
 
 def count_significant_isoforms(script_dir, out_dir, python_executable,
-                               adj_pvalue, delta_proportion):
+                               adj_pvalue, use_unadjusted_pvalue,
+                               delta_proportion):
     count_script_path = os.path.join(script_dir,
                                      'count_significant_isoforms.py')
     diff_transcripts = os.path.join(out_dir, 'differential_transcripts.tsv')
@@ -117,6 +121,9 @@ def count_significant_isoforms(script_dir, out_dir, python_executable,
         str(adj_pvalue), '--delta-proportion',
         str(delta_proportion)
     ]
+    if use_unadjusted_pvalue:
+        command.append('--use-unadjusted-pvalue')
+
     rmats_long_utils.run_command(command)
 
 
@@ -130,7 +137,8 @@ def detect_differential_isoforms(args):
     calculate_isoform_proportion(script_dir, args.out_dir, args.abundance,
                                  args.group_1, args.group_2, python_executable)
     count_significant_isoforms(script_dir, args.out_dir, python_executable,
-                               args.adj_pvalue, args.delta_proportion)
+                               args.adj_pvalue, args.use_unadjusted_pvalue,
+                               args.delta_proportion)
 
 
 def main():


### PR DESCRIPTION
* Allows using pvalue instead of adj_pvalue to filter significant isoforms